### PR TITLE
bug fix tokenAmountNeededAndETHPayout

### DIFF
--- a/src/TokenBuyer.sol
+++ b/src/TokenBuyer.sol
@@ -302,10 +302,25 @@ contract TokenBuyer is Ownable, Pausable, ReentrancyGuard {
         uint256 ethAmount = ethAmountPerTokenAmount(tokenAmount);
         uint256 ethAvailable = address(this).balance;
 
+        // If there's enough ETH balance to pay for the tokens needed
+        if (ethAvailable >= ethAmount) {
+            return (tokenAmount, ethAmount);
+        }
+
+        // How many tokens are needed to buy the available ETH
+        tokenAmount = tokenAmountPerEthAmount(ethAvailable);
+
+        // Check again how much eth this amount of tokens would buy
+        // This may be higher than `ethAvailable` because `tokenAmountPerEthAmount` rounds up
+        ethAmount = ethAmountPerTokenAmount(tokenAmount);
+
         if (ethAvailable >= ethAmount) {
             return (tokenAmount, ethAmount);
         } else {
-            return (tokenAmountPerEthAmount(ethAvailable), ethAvailable);
+            tokenAmount--;
+            ethAmount = ethAmountPerTokenAmount(tokenAmount);
+
+            return (tokenAmount, ethAmount);
         }
     }
 

--- a/test/Payer.t.sol
+++ b/test/Payer.t.sol
@@ -22,7 +22,7 @@ contract PayerTest is Test {
     address user3 = address(0x1236);
 
     function setUp() public {
-        paymentToken = new TestERC20('Payment Token', 'PAY');
+        paymentToken = new TestERC20('Payment Token', 'PAY', 18);
         payer = new Payer(owner, address(paymentToken));
         vm.label(user, 'user');
     }

--- a/test/helpers/TestERC20.sol
+++ b/test/helpers/TestERC20.sol
@@ -4,9 +4,21 @@ pragma solidity ^0.8.15;
 import { ERC20 } from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
 
 contract TestERC20 is ERC20 {
-    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+    uint8 internal immutable _decimals;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 numDecimals
+    ) ERC20(name_, symbol_) {
+        _decimals = numDecimals;
+    }
 
     function mint(address account, uint256 amount) public {
         _mint(account, amount);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
     }
 }


### PR DESCRIPTION
in case all the available ETH can be used for swapping for tokens when calculating the amount of tokens needed to buy that eth, the resulting eth amount may be higher than available because of rounding.
In that case, the function returns one less token, which would buy slightly less than the available eth